### PR TITLE
Fix bug around half-dead people

### DIFF
--- a/src/nanowar.ts
+++ b/src/nanowar.ts
@@ -49,7 +49,7 @@ async function makeMatch(state: GameState, botPool: BotPool) {
   }
   let isThereAliveBot = true;
   tickToVisualizer(botPool, state); // Save for visualizer
-  while ((isThereAliveBot || state.tick.troops.length !== 0) && state.tick.id < 300) {
+  while ((isThereAliveBot) && state.tick.id < 300) {
     state.tick.id++;
     console.log(`${formatTime()}: tick #${state.tick.id}`);
     console.log(state.tick.planets);
@@ -85,7 +85,7 @@ async function makeMatch(state: GameState, botPool: BotPool) {
         state.tick.planets.map((planet) => planet.player?.id).filter((id) => id !== undefined),
       ),
     );
-    if (playersAlive.length < 2) isThereAliveBot = false;
+    if (playersAlive.length < 2 && state.tick.troops.length !== 0) isThereAliveBot = false;
   }
   console.log(`${formatTime()} match finished`);
   stateToVisualizer(botPool, state);


### PR DESCRIPTION
isThereBotAlive is *always* updated to false when one of them has no planet. The check has an additional, separate constraint: troops.size === 0. This constraint is in the `while(...game is running...)`.

So the problem is:
1) There is a moment when the player has no planets. At this moment isThereBotAlive is updated to false. 2) The game is still running because of the extra constraint. 3) The last troops arrive. Even though the player has acquired a new planet, isThereBotAlive flag is already reset. The game ends at this point.